### PR TITLE
Fix heading title errors. 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,3 +6,32 @@ image:images/keycloak_logo.png[alt="Keycloak"]
 {{book.project.name}} {{book.project.version}}
 
 http://www.keycloak.org
+
+
+== Test the Product Build
+
+Follow the steps below to test that this documentation for the product build.
+
+. In a terminal, navigate to the root folder of this project source.
+. Convert the content by running the following Python command.
++
+[source,options="nowrap"]
+----
+$ python gitlab-conversion.py
+----
+. This command puts the converted content in the `target/` directory.
+. Copy the `buildGuide.sh` script from the root of the project folder to the `target/` directory.
++
+[source,options="nowrap"]
+----
+cp buildGuide.sh target/
+----
+. Navigate to the `target/` directory and build the documentation to be sure there are no errors.
++
+[source,options="nowrap"]
+----
+./buildGuide.sh
+----
+. Open the link provided as a result of the build and visually check the guide to make sure it is correctly formatted.
+* Search for '<<' to find links that were not converted.
+* Search for '==' to find titles that are not rendered correctly.

--- a/SUMMARY.adoc
+++ b/SUMMARY.adoc
@@ -1,52 +1,101 @@
 = {{book.title}}
 
  . link:topics/overview/overview.adoc[Overview]
+
  .. link:topics/overview/architecture.adoc[Architecture]
+
  .. link:topics/overview/terminology.adoc[Terminology]
+
  . link:topics/getting-started/overview.adoc[Getting Started]
+
  .. link:topics/getting-started/hello-world/overview.adoc[Securing a Servlet Application]
+
  ... link:topics/getting-started/hello-world/create-realm.adoc[Creating a Realm]
+
  ... link:topics/getting-started/hello-world/create-resource-server.adoc[Enabling Authorization Services]
+
  ... link:topics/getting-started/hello-world/deploy.adoc[Build, Deploy and Test]
+
  .. link:topics/example/overview.adoc[Examples]
+
  . link:topics/resource-server/overview.adoc[Managing Resource Servers]
+
  .. link:topics/resource-server/create-client.adoc[Creating a Client Application]
+
  .. link:topics/resource-server/enable-authorization.adoc[Enabling Authorization Services]
+
  .. link:topics/resource-server/default-config.adoc[Default Configuration]
+
  .. link:topics/resource-server/import-config.adoc[Exporting and Importing Authorization Configuration]
+
  . link:topics/resource/overview.adoc[Managing Resources]
+
  .. link:topics/resource/view.adoc[Viewing Resources]
+
  .. link:topics/resource/create.adoc[Creating Resources]
+
  . link:topics/policy/overview.adoc[Managing Policies]
+
  .. link:topics/policy/user-policy.adoc[User-Based Policy]
+
  .. link:topics/policy/role-policy.adoc[Role-Based Policy]
+
  ... link:topics/policy/role-policy-required-role.adoc[Defining a Role as Required]
+
  .. link:topics/policy/js-policy.adoc[JavaScript-Based Policy]
+
  .. link:topics/policy/drools-policy.adoc[Rule-Based Policy]
+
  .. link:topics/policy/time-policy.adoc[Time-Based Policy]
+
  .. link:topics/policy/aggregated-policy.adoc[Aggregated Policy]
+
  .. link:topics/policy/logic.adoc[Positive and Negative Logic]
+
  .. link:topics/policy/evaluation-api.adoc[Policy Evaluation API]
+
  . link:topics/permission/overview.adoc[Managing Permissions]
+
  .. link:topics/permission/create-resource.adoc[Creating Resource-based Permissions]
+
  ... link:topics/permission/typed-resource-permission.adoc[Typed Resource Permissions]
+
  .. link:topics/permission/create-scope.adoc[Creating Scope-based Permissions]
+
  .. link:topics/permission/decision-strategy.adoc[Policy Decision Strategies]
+
  . link:topics/policy-evaluation-tool/overview.adoc[Evaluating and Testing Policies]
+
  . link:topics/service/overview.adoc[Authorization Services]
+
  .. link:topics/service/protection/protection-api.adoc[Protection API]
+
  ... link:topics/service/protection/whatis-obtain-pat.adoc[What is a PAT and How to Obtain It]
+
  ... link:topics/service/protection/resources-api-papi.adoc[Managing Resources]
+
  ... link:topics/service/protection/permission-api-papi.adoc[Managing Permission Requests]
+
  .. link:topics/service/authorization/authorization-api.adoc[Authorization API]
+
  ... link:topics/service/authorization/whatis-obtain-aat.adoc[What is a AAT and How to Obtain It]
+
  ... link:topics/service/authorization/authorization-api-aapi.adoc[Requesting Authorization Data and Token]
+
  .. link:topics/service/entitlement/entitlement-api.adoc[Entitlement API]
+
  ... link:topics/service/entitlement/entitlement-api-aapi.adoc[Requesting Entitlements]
+
  .. link:topics/service/protection/token-introspection.adoc[Introspecting a Requesting Party Token]
+
  .. link:topics/service/client-api.adoc[Authorization Client Java API]
+
  . link:topics/enforcer/overview.adoc[Policy Enforcers]
+
  .. link:topics/enforcer/keycloak-enforcement-filter.adoc[{{book.project.name}} Adapter Policy Enforcer]
+
  ... link:topics/enforcer/keycloak-enforcement-bearer.adoc[Protecting a Stateless Service Using a Bearer Token]
+
  ... link:topics/enforcer/authorization-context.adoc[Obtaining the Authorization Context]
+
  ... link:topics/enforcer/js-adapter.adoc[JavaScript Integration]

--- a/buildGuide.sh
+++ b/buildGuide.sh
@@ -1,0 +1,48 @@
+# Build the guide
+
+# Find the directory name and full path
+CURRENT_GUIDE=${PWD##*/}
+CURRENT_DIRECTORY=$(pwd)
+
+usage(){
+  cat <<EOM
+USAGE: $0 [OPTION]
+
+DESCRIPTION: Build the documentation in this directory.
+
+OPTIONS:
+  -h       Print help.
+
+EOM
+}
+
+while getopts "ht:" c
+ do
+     case "$c" in
+       h)         usage
+                  exit 1;;
+       \?)        echo "Unknown option: -$OPTARG." >&2
+                  usage
+                  exit 1;;
+     esac
+done
+
+# Remove the html and build directories and then recreate the html/images/ directory
+if [ -d html ]; then
+   rm -r html/
+fi
+
+mkdir -p html
+cp -r ../../docs/topics/images/ html/
+
+echo ""
+echo "********************************************"
+echo " Building $CURRENT_GUIDE                "
+echo "********************************************"
+echo ""
+echo "Building an asciidoctor version of the $CURRENT_GUIDE"
+asciidoctor -t -dbook -a toc -o html/$CURRENT_GUIDE.html master.adoc
+
+cd ..
+
+echo "View the guide here: " file://$CURRENT_DIRECTORY/html/$CURRENT_GUIDE.html

--- a/topics/enforcer/keycloak-enforcement-filter.adoc
+++ b/topics/enforcer/keycloak-enforcement-filter.adoc
@@ -103,7 +103,7 @@ Specifies the paths to protect.
 The name of a resource on the server that is to be associated with a given path. When used in conjunction with a *path*, the policy enforcer ignores the resource's *URI* property and uses the path you provided instead.
 *** *path*
 +
-(required) A URI relative to the application's context path. If this option is specified, the policy enforcer queries the server for a resource with a *URI* with the same value. 
+(required) A URI relative to the application's context path. If this option is specified, the policy enforcer queries the server for a resource with a *URI* with the same value.
 Currently a very basic logic for path matching is supported. Examples of valid paths are:
 +
 **** Wildcards: `/*`
@@ -134,4 +134,3 @@ Specifies how policies are enforced.
 **** *DISABLED*
 +
 Disables the evaluation of policies for a path
-+


### PR DESCRIPTION
 Add a blank line between each include in the SUMMARY.adoc file to fix title build errors. 
Remove trailing + line in the enforcer/keycloak-enforcement-filter.adoc file. 
Add a buildGuide.sh and instructions to use it in the README.adoc file.