### PR TITLE
Simplify the script to test the build of the converted content.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -13,20 +13,14 @@ http://www.keycloak.org
 Follow the steps below to test that this documentation for the product build.
 
 . In a terminal, navigate to the root folder of this project source.
-. Convert the content by running the following Python command.
+. Run the following Python command to convert the content and put it in the the `target/` directory.
 +
 [source,options="nowrap"]
 ----
 $ python gitlab-conversion.py
 ----
-. This command puts the converted content in the `target/` directory.
-. Copy the `buildGuide.sh` script from the root of the project folder to the `target/` directory.
-+
-[source,options="nowrap"]
-----
-cp buildGuide.sh target/
-----
-. Navigate to the `target/` directory and build the documentation to be sure there are no errors.
+
+. Build the documentation to be sure there are no errors.
 +
 [source,options="nowrap"]
 ----

--- a/buildGuide.sh
+++ b/buildGuide.sh
@@ -27,13 +27,18 @@ while getopts "ht:" c
      esac
 done
 
+if [ ! -d target ]; then
+   echo "You must run 'python gitlab-conversion.py' to convert the content before you run this script."
+   exit
+fi
+
 # Remove the html and build directories and then recreate the html/images/ directory
-if [ -d html ]; then
-   rm -r html/
+if [ -d target/html ]; then
+   rm -r target/html/
 fi
 
 mkdir -p html
-cp -r ../../docs/topics/images/ html/
+cp -r target/images/ target/html/
 
 echo ""
 echo "********************************************"
@@ -41,8 +46,8 @@ echo " Building $CURRENT_GUIDE                "
 echo "********************************************"
 echo ""
 echo "Building an asciidoctor version of the $CURRENT_GUIDE"
-asciidoctor -t -dbook -a toc -o html/$CURRENT_GUIDE.html master.adoc
+asciidoctor -t -dbook -a toc -o target/html/$CURRENT_GUIDE.html target/master.adoc
 
 cd ..
 
-echo "View the guide here: " file://$CURRENT_DIRECTORY/html/$CURRENT_GUIDE.html
+echo "View the guide here: " file://$CURRENT_DIRECTORY/target/html/$CURRENT_GUIDE.html


### PR DESCRIPTION
You no longer need to copy the build script into the target directory to build the guide.