### PR TITLE
Replace hard-coded links to books with variables.

### DIFF
--- a/book-product.json
+++ b/book-product.json
@@ -16,16 +16,18 @@
     "project": {
       "name": "Red Hat Single Sign-On",
       "version": "7.0.0",
-      "module": "Authorization Services"
+      "module": "Authorization Services",
+      "doc-base-url": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/",
+      "doc-info-version-url": "7.0-Beta"
     },
     "external_link": {
       "keycloakjsadapter": {
         "name": "JavaScript OpenID Connect Adapter",
-        "link": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/7.0/securing-applications-and-services-guide/securing-applications-and-services-guide#javascript_adapter"
+        "link": "/securing-applications-and-services-guide#javascript_adapter"
       },
       "keycloakgettingstarted": {
         "name": "Getting Started",
-        "link": "https://access.redhat.com/documentation/en/red-hat-single-sign-on/7.0/paged/getting-started-guide/"
+        "link": "/paged/getting-started-guide/"
       }
     }
   }

--- a/topics/enforcer/js-adapter.adoc
+++ b/topics/enforcer/js-adapter.adoc
@@ -2,7 +2,7 @@
 ==== JavaScript Integration
 
 The {{book.project.name}} Server comes with a JavaScript library you can use to interact with a resource server protected by a policy enforcer.
-This library is based on the link:{{book.external_link.keycloakjsadapter.link}}[{{book.project.name}} {{book.external_link.keycloakjsadapter.name}}], which can be integrated to allow your client to obtain permissions from a {{book.project.name}} Server.
+This library is based on the link:{{book.project.doc-base-url}}{{book.project.doc-info-version-url}}{{book.external_link.keycloakjsadapter.link}}[{{book.project.name}} {{book.external_link.keycloakjsadapter.name}}], which can be integrated to allow your client to obtain permissions from a {{book.project.name}} Server.
 
 You can obtain this library from a running a {{book.project.name}} Server instance by including the following `script` tag in your web page:
 

--- a/topics/getting-started/overview.adoc
+++ b/topics/getting-started/overview.adoc
@@ -9,7 +9,7 @@ To unpack this file run the _unzip_ or _gunzip_ and _tar_ utilities. Throughout 
 the demo distribution is referenced as *${KEYCLOAK_DEMO_SERVER_DIR}*.
 
 [NOTE]
-This guide assumes that you are already familiar with {{book.project.name}} and that you are able to install and boot a {{book.project.name}} Server. For more information, see the link:{{book.external_link.keycloakgettingstarted.link}}[{{book.external_link.keycloakgettingstarted.name}}] tutorials.
+This guide assumes that you are already familiar with {{book.project.name}} and that you are able to install and boot a {{book.project.name}} Server. For more information, see the link:{{book.project.doc-base-url}}{{book.project.doc-info-version-url}}{{book.external_link.keycloakgettingstarted.link}}[{{book.external_link.keycloakgettingstarted.name}}] tutorials.
 
 Ensure you have a {{book.project.name}} instance running; the default configuration is http://localhost:8080/auth[http://localhost:8080/auth]. After logging in to the
 Administration Console, a page similar to this one is displayed:


### PR DESCRIPTION
I separated the URLs into the documentation base URL, the version, and the book link and created separate variables for each. Then, in the files that referenced them, I concatenated them to build the URL.